### PR TITLE
Security hardening: fix quick-win findings from review

### DIFF
--- a/src/zodb_s3blobs/cache.py
+++ b/src/zodb_s3blobs/cache.py
@@ -34,7 +34,7 @@ class S3BlobCache:
         self._bytes_loaded = 0
         self._lock = threading.Lock()
         self._checker_thread = None
-        os.makedirs(cache_dir, exist_ok=True)
+        os.makedirs(cache_dir, exist_ok=True, mode=0o700)
 
     def _blob_path(self, oid, tid):
         oid_hex = _hex(oid)
@@ -63,7 +63,10 @@ class S3BlobCache:
                 self._start_cleanup()
 
     def _start_cleanup(self):
-        """Start background cleanup thread if not already running."""
+        """Start background cleanup thread if not already running.
+
+        Must be called with self._lock held.
+        """
         if self._checker_thread is not None and self._checker_thread.is_alive():
             return
         t = threading.Thread(target=self._cleanup, daemon=True)


### PR DESCRIPTION
## Summary
- Add `OverflowError` to `_oid_from_key` exception handler — prevents `pack()` crash from crafted S3 key names with huge hex values
- Restrict temp and cache directory permissions to `0o700` — prevents world-readable blob data on shared systems
- Remove `list()` materialization in `pack()` GC loop — keeps S3 listing lazy to avoid memory issues with large buckets
- Document `_start_cleanup` lock requirement — clarifies thread-safety contract
- Clean up temp directory on `close()` — prevents disk space leakage from accumulated staging files

## Test plan
- [x] Added `TestOidFromKey` tests including overflow case
- [x] Added `TestDirectoryPermissions` tests for temp and cache dirs
- [x] Added `test_close_cleans_temp_dir` test
- [x] All 80 tests pass, 95.27% coverage

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)